### PR TITLE
feat: Story 5 hecate start + hecate-git + task layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,75 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -24,10 +89,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -102,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,7 +310,13 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 name = "hecate"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "clap",
+ "hecate-config",
  "hecate-core",
+ "hecate-git",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -191,6 +347,10 @@ dependencies = [
 [[package]]
 name = "hecate-git"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "hecate-host"
@@ -217,6 +377,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,10 +419,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -280,10 +480,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -348,6 +563,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -417,6 +638,18 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -522,6 +755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +788,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -586,10 +870,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ rust-version = "1.85"
 unsafe_code = "forbid"
 
 [workspace.dependencies]
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+clap = { version = "4", features = ["derive"] }
 dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/PRD.md
+++ b/PRD.md
@@ -334,6 +334,13 @@ Implement:
 - worktree creation
 - metadata registration
 
+Implementation notes:
+
+- **`hecate-core::task`:** `task_layout` → git branch `task/<slug>` and worktree directory name `<slug>` via `sanitize_segment`.
+- **`hecate-git`:** subprocess `git` — `rev-parse --show-toplevel`, `symbolic-ref` for current branch (error if detached), `worktree add -b`, `rev-parse --verify` for existing branches.
+- **CLI:** `hecate start <task>` and optional `--cwd DIR`; requires configured `hecate_root`, non-detached HEAD, and no duplicate branch / registered worktree for that task.
+- **Paths:** `resolve_hecate_root`, `choose_repo_segment`, `worktree_directory`; metadata key `clone_identity_key(repo_root)`.
+
 ### Story 6: `hecate list`
 
 Implement:

--- a/apps/hecate/Cargo.toml
+++ b/apps/hecate/Cargo.toml
@@ -8,7 +8,17 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+chrono = { workspace = true }
+clap = { workspace = true }
+hecate-config = { path = "../../crates/hecate-config" }
 hecate-core = { path = "../../crates/hecate-core" }
+hecate-git = { path = "../../crates/hecate-git" }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+hecate-config = { path = "../../crates/hecate-config" }
+hecate-core = { path = "../../crates/hecate-core" }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/apps/hecate/src/lib.rs
+++ b/apps/hecate/src/lib.rs
@@ -1,0 +1,3 @@
+//! Library surface for the Hecate CLI (shared with integration tests).
+
+pub mod start;

--- a/apps/hecate/src/main.rs
+++ b/apps/hecate/src/main.rs
@@ -1,6 +1,39 @@
-//! Hecate user CLI entrypoint (implementation in later stories).
+//! Hecate user CLI.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "hecate", version, about = "Task-aware Git worktrees")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a new branch and worktree for a task, and register it in metadata.
+    Start {
+        /// Task label (e.g. issue number or short slug); becomes directory name and `task/<slug>` branch.
+        task: String,
+        /// Run as if started in this directory (must be inside a Git repo).
+        #[arg(long, value_name = "DIR")]
+        cwd: Option<PathBuf>,
+    },
+}
 
 fn main() {
-    assert!(hecate_core::workspace_ok(), "core crate should link");
-    println!("hecate {}", env!("CARGO_PKG_VERSION"));
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Start { task, cwd } => {
+            let base = cwd
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| PathBuf::from("."));
+            if let Err(e) = hecate::start::run(&task, &base) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+    }
 }

--- a/apps/hecate/src/start.rs
+++ b/apps/hecate/src/start.rs
@@ -1,0 +1,107 @@
+//! `hecate start <task>` — create branch + worktree and register in metadata.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use hecate_config::{
+    LoadOptions, ResolveHecateRootError, WorktreeRecord, choose_repo_segment, clone_identity_key,
+    load, read_metadata, resolve_hecate_root, write_metadata,
+};
+use hecate_core::{PathError, task_layout, worktree_directory};
+use hecate_git::GitRepo;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StartError {
+    #[error(transparent)]
+    Git(#[from] hecate_git::GitError),
+
+    #[error(transparent)]
+    Config(#[from] hecate_config::ConfigError),
+
+    #[error(transparent)]
+    ResolveRoot(#[from] ResolveHecateRootError),
+
+    #[error(transparent)]
+    Path(#[from] PathError),
+
+    #[error(transparent)]
+    Metadata(#[from] hecate_config::MetadataError),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("worktree path already exists: {0}", path.display())]
+    PathExists { path: PathBuf },
+
+    #[error(
+        "this clone already has a registered worktree for this task (name `{name}`, branch `{branch}`)"
+    )]
+    AlreadyRegistered { name: String, branch: String },
+
+    #[error("branch `{0}` already exists locally; remove it or use a different task label")]
+    BranchExists(String),
+}
+
+pub fn run(task: &str, cwd: &Path) -> Result<(), StartError> {
+    let git = GitRepo::discover(cwd)?;
+    let base_branch = git.current_branch()?;
+
+    let opts = LoadOptions {
+        repo_root: Some(git.root().to_path_buf()),
+        config_home_override: None,
+    };
+    let cfg = load(&opts)?;
+    let hecate_root = resolve_hecate_root(cfg.hecate_root.as_deref(), git.root())?;
+
+    let clone_key = clone_identity_key(git.root());
+    let mut meta = read_metadata(&hecate_root)?;
+    let repo_segment = choose_repo_segment(git.root(), &hecate_root, &meta, &clone_key)?;
+
+    let (branch, worktree_name) = task_layout(task)?;
+
+    if let Some(list) = meta.repos.get(&clone_key) {
+        for r in list {
+            if r.name == worktree_name || r.branch == branch {
+                return Err(StartError::AlreadyRegistered {
+                    name: r.name.clone(),
+                    branch: r.branch.clone(),
+                });
+            }
+        }
+    }
+
+    if git.local_branch_exists(&branch)? {
+        return Err(StartError::BranchExists(branch));
+    }
+
+    let wt_path = worktree_directory(&hecate_root, &repo_segment, &worktree_name)?;
+    if wt_path.exists() {
+        return Err(StartError::PathExists { path: wt_path });
+    }
+
+    std::fs::create_dir_all(hecate_root.join(&repo_segment))?;
+
+    git.worktree_add_branch(&wt_path, &branch, "HEAD")?;
+
+    let path_abs = std::path::absolute(&wt_path)?;
+    let record = WorktreeRecord {
+        name: worktree_name.clone(),
+        path: path_abs,
+        branch: branch.clone(),
+        base_branch,
+        task: Some(task.trim().to_string()),
+        created_at: Utc::now().to_rfc3339(),
+        updated_at: None,
+        session: None,
+    };
+
+    meta.repos.entry(clone_key).or_default().push(record);
+
+    write_metadata(&hecate_root, &meta)?;
+
+    println!("Created worktree at {}", wt_path.display());
+    println!("Branch: {branch}");
+
+    Ok(())
+}

--- a/apps/hecate/tests/start_workflow.rs
+++ b/apps/hecate/tests/start_workflow.rs
@@ -1,0 +1,65 @@
+//! End-to-end `hecate start` against a real git repo (requires `git` on PATH).
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn init_repo(path: &Path) {
+    assert!(
+        Command::new("git")
+            .current_dir(path)
+            .args(["init", "-b", "main"])
+            .status()
+            .expect("git")
+            .success(),
+        "git init failed — is git installed?"
+    );
+    for (k, v) in [("user.email", "t@e.co"), ("user.name", "t")] {
+        Command::new("git")
+            .current_dir(path)
+            .args(["config", k, v])
+            .status()
+            .unwrap();
+    }
+    fs::write(path.join("f.txt"), "x\n").unwrap();
+    Command::new("git")
+        .current_dir(path)
+        .args(["add", "f.txt"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .current_dir(path)
+        .args(["commit", "-m", "i"])
+        .status()
+        .unwrap();
+}
+
+#[test]
+fn start_registers_worktree_and_metadata() {
+    let parking = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+
+    let hecate_dir = repo.path().join(".hecate");
+    fs::create_dir_all(&hecate_dir).unwrap();
+    let root_str = parking.path().to_string_lossy().replace('\\', "/");
+    fs::write(
+        hecate_dir.join("config.toml"),
+        format!("hecate_root = \"{root_str}\"\n"),
+    )
+    .unwrap();
+
+    hecate::start::run("77", repo.path()).expect("start");
+
+    let seg = hecate_core::repo_default_segment(repo.path()).unwrap();
+    let wt = parking.path().join(&seg).join("77");
+    assert!(wt.join("f.txt").exists(), "worktree checkout missing");
+
+    let meta = hecate_config::read_metadata(parking.path()).unwrap();
+    let key = hecate_config::clone_identity_key(repo.path());
+    let list = meta.repos.get(&key).expect("repo key");
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].branch, "task/77");
+    assert_eq!(list[0].name, "77");
+    assert_eq!(list[0].task.as_deref(), Some("77"));
+}

--- a/crates/hecate-core/src/lib.rs
+++ b/crates/hecate-core/src/lib.rs
@@ -1,8 +1,10 @@
 //! Domain models and application services.
 
 pub mod paths;
+pub mod task;
 
 pub use paths::{PathError, repo_default_segment, sanitize_segment, worktree_directory};
+pub use task::task_layout;
 
 /// Sanity check that the workspace links; replaced as features land.
 pub const fn workspace_ok() -> bool {

--- a/crates/hecate-core/src/task.rs
+++ b/crates/hecate-core/src/task.rs
@@ -1,0 +1,30 @@
+//! Task token parsing for branch names and worktree directory segments.
+
+use crate::paths::{PathError, sanitize_segment};
+
+/// Git branch name (`task/<slug>`) and worktree directory name (`<slug>`) for a CLI task.
+///
+/// The slug is [`sanitize_segment`] of the trimmed task string (e.g. `42` → `task/42` / `42`).
+pub fn task_layout(task: &str) -> Result<(String, String), PathError> {
+    let slug = sanitize_segment(task.trim())?;
+    Ok((format!("task/{slug}"), slug))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_task() {
+        let (b, w) = task_layout("42").unwrap();
+        assert_eq!(b, "task/42");
+        assert_eq!(w, "42");
+    }
+
+    #[test]
+    fn slug_task() {
+        let (b, w) = task_layout("Fix the thing").unwrap();
+        assert_eq!(b, "task/fix-the-thing");
+        assert_eq!(w, "fix-the-thing");
+    }
+}

--- a/crates/hecate-git/Cargo.toml
+++ b/crates/hecate-git/Cargo.toml
@@ -7,5 +7,11 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/hecate-git/src/lib.rs
+++ b/crates/hecate-git/src/lib.rs
@@ -1,1 +1,185 @@
-//! Subprocess `git` integration (later stories).
+//! Subprocess `git` integration (v1).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GitError {
+    #[error("failed to run git: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("git command failed: {stderr}\ncommand: {cmd:?}")]
+    Failed { cmd: Vec<String>, stderr: String },
+
+    #[error("not a git repository (or git failed to read it)")]
+    NotARepository,
+
+    #[error("detached HEAD; check out a branch before running this command")]
+    DetachedHead,
+
+    #[error("utf-8 decode of git output failed")]
+    Utf8,
+}
+
+fn git_output(workdir: &Path, args: &[&str]) -> Result<String, GitError> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GitError::Failed {
+            cmd: std::iter::once("git".to_string())
+                .chain(args.iter().map(|s| (*s).to_string()))
+                .collect(),
+            stderr,
+        });
+    }
+
+    String::from_utf8(output.stdout)
+        .map(|s| s.trim().to_string())
+        .map_err(|_| GitError::Utf8)
+}
+
+/// Open repository at `root` (top-level directory).
+#[derive(Debug, Clone)]
+pub struct GitRepo {
+    root: PathBuf,
+}
+
+impl GitRepo {
+    /// Use `git rev-parse --show-toplevel` starting from `start` (e.g. current directory).
+    pub fn discover(start: &Path) -> Result<Self, GitError> {
+        let top = git_output(start, &["rev-parse", "--show-toplevel"]).map_err(|e| {
+            if matches!(e, GitError::Failed { .. }) {
+                GitError::NotARepository
+            } else {
+                e
+            }
+        })?;
+        Ok(Self {
+            root: PathBuf::from(top),
+        })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Short name of the checked-out branch, or [`GitError::DetachedHead`].
+    pub fn current_branch(&self) -> Result<String, GitError> {
+        let out = git_output(self.root(), &["symbolic-ref", "-q", "--short", "HEAD"]).map_err(
+            |e| match e {
+                GitError::Failed { .. } => GitError::DetachedHead,
+                other => other,
+            },
+        )?;
+        if out.is_empty() {
+            return Err(GitError::DetachedHead);
+        }
+        Ok(out)
+    }
+
+    /// Whether `refs/heads/{branch}` exists.
+    pub fn local_branch_exists(&self, branch: &str) -> Result<bool, GitError> {
+        let refname = format!("refs/heads/{branch}");
+        let out = Command::new("git")
+            .current_dir(self.root())
+            .args(["rev-parse", "--verify", &refname])
+            .output()?;
+        Ok(out.status.success())
+    }
+
+    /// `git worktree add -b <new_branch> <path> <start_point>`.
+    pub fn worktree_add_branch(
+        &self,
+        path: &Path,
+        new_branch: &str,
+        start_point: &str,
+    ) -> Result<(), GitError> {
+        let output = Command::new("git")
+            .current_dir(self.root())
+            .args(["worktree", "add", "-b", new_branch])
+            .arg(path)
+            .arg(start_point)
+            .output()?;
+
+        if !output.status.success() {
+            return Err(GitError::Failed {
+                cmd: vec![
+                    "git".into(),
+                    "worktree".into(),
+                    "add".into(),
+                    "-b".into(),
+                    new_branch.into(),
+                    path.display().to_string(),
+                    start_point.into(),
+                ],
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    fn init_repo(path: &Path) {
+        let status = Command::new("git")
+            .current_dir(path)
+            .args(["init", "-b", "main"])
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init failed — is git installed?");
+        Command::new("git")
+            .current_dir(path)
+            .args(["config", "user.email", "hecate-test@example.com"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .current_dir(path)
+            .args(["config", "user.name", "hecate-test"])
+            .status()
+            .unwrap();
+        fs::write(path.join("README.md"), "x\n").unwrap();
+        Command::new("git")
+            .current_dir(path)
+            .args(["add", "README.md"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .current_dir(path)
+            .args(["commit", "-m", "init"])
+            .status()
+            .unwrap();
+    }
+
+    #[test]
+    fn discover_and_branch_and_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        let repo = GitRepo::discover(tmp.path()).unwrap();
+        assert_eq!(repo.root(), tmp.path());
+        assert_eq!(repo.current_branch().unwrap(), "main");
+        assert!(!repo.local_branch_exists("task/1").unwrap());
+
+        let wt = tmp.path().join("wt-side");
+        repo.worktree_add_branch(&wt, "task/1", "HEAD").unwrap();
+        assert!(wt.join("README.md").exists());
+        assert!(repo.local_branch_exists("task/1").unwrap());
+    }
+
+    #[test]
+    fn discover_non_repo_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = GitRepo::discover(tmp.path()).unwrap_err();
+        assert!(matches!(err, GitError::NotARepository));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **PRD Story 5**: `hecate start <task>` — task parsing, branch naming (`task/<slug>`), `git worktree add`, and metadata registration under the configured `hecate_root`.

### hecate-core

- New `task` module: `task_layout` maps a CLI task token to `(branch, worktree_dir_name)` using existing `sanitize_segment`.

### hecate-git

- Subprocess Git adapter: `GitRepo::discover`, `current_branch` (errors on detached HEAD), `local_branch_exists`, `worktree_add_branch` (`git worktree add -b …`).
- Unit tests (require `git` on PATH).

### apps/hecate

- `hecate start <task>` with optional `--cwd DIR`.
- `lib` + `start` module; wires `load`, `resolve_hecate_root`, `read_metadata` / `write_metadata`, `choose_repo_segment`, `clone_identity_key`, `worktree_directory`.
- Dependencies: `clap`, `chrono`, `hecate-config`, `hecate-core`, `hecate-git`, `thiserror`.

### Integration test

- `tests/start_workflow.rs`: temp repo + `.hecate/config.toml` → `start::run` → asserts worktree on disk and `metadata.json` entry.

### Workspace / PRD

- `[workspace.dependencies]`: `clap`, `chrono`.
- PRD: Story 5 implementation notes.

## Testing

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.

## Usage

Configure `hecate_root` (user or repo `config.toml`, or `HECATE_ROOT`), checkout a branch in the main clone, then:

```text
hecate start <task>
```