### PR TITLE
feat(cli): hecate list with human and --json output (Story 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,8 @@ dependencies = [
  "hecate-config",
  "hecate-core",
  "hecate-git",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
 ]

--- a/PRD.md
+++ b/PRD.md
@@ -349,6 +349,11 @@ Implement:
 - `--json`
 - metadata-aware task display
 
+Implementation notes:
+
+- **`hecate list`** / **`hecate list --json`**: optional **`--cwd`**; resolves `hecate_root`, `clone_identity_key`, `read_metadata`, prints worktrees for this clone only (name, branch, base branch, task, path, created).
+- **Library:** `hecate::list::worktrees_for_cwd` for tests and reuse.
+
 ### Story 7: `hecate rm`
 
 Implement:

--- a/apps/hecate/Cargo.toml
+++ b/apps/hecate/Cargo.toml
@@ -13,6 +13,8 @@ clap = { workspace = true }
 hecate-config = { path = "../../crates/hecate-config" }
 hecate-core = { path = "../../crates/hecate-core" }
 hecate-git = { path = "../../crates/hecate-git" }
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/apps/hecate/src/lib.rs
+++ b/apps/hecate/src/lib.rs
@@ -1,3 +1,4 @@
 //! Library surface for the Hecate CLI (shared with integration tests).
 
+pub mod list;
 pub mod start;

--- a/apps/hecate/src/list.rs
+++ b/apps/hecate/src/list.rs
@@ -1,0 +1,103 @@
+//! `hecate list` — show worktrees for the current clone from metadata.
+
+use std::io::{self, Write};
+use std::path::Path;
+
+use hecate_config::{
+    LoadOptions, ResolveHecateRootError, WorktreeRecord, clone_identity_key, load, read_metadata,
+    resolve_hecate_root,
+};
+use hecate_git::GitRepo;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ListError {
+    #[error(transparent)]
+    Git(#[from] hecate_git::GitError),
+
+    #[error(transparent)]
+    Config(#[from] hecate_config::ConfigError),
+
+    #[error(transparent)]
+    ResolveRoot(#[from] ResolveHecateRootError),
+
+    #[error(transparent)]
+    Metadata(#[from] hecate_config::MetadataError),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+#[derive(Serialize)]
+struct ListJson<'a> {
+    worktrees: &'a [WorktreeRecord],
+}
+
+/// Load registered worktrees for the main clone containing `cwd`.
+pub fn worktrees_for_cwd(cwd: &Path) -> Result<Vec<WorktreeRecord>, ListError> {
+    let git = GitRepo::discover(cwd)?;
+    let opts = LoadOptions {
+        repo_root: Some(git.root().to_path_buf()),
+        config_home_override: None,
+    };
+    let cfg = load(&opts)?;
+    let hecate_root = resolve_hecate_root(cfg.hecate_root.as_deref(), git.root())?;
+    let clone_key = clone_identity_key(git.root());
+    let meta = read_metadata(&hecate_root)?;
+    Ok(meta.repos.get(&clone_key).cloned().unwrap_or_default())
+}
+
+pub fn run(cwd: &Path, json: bool) -> Result<(), ListError> {
+    let records = worktrees_for_cwd(cwd)?;
+    if json {
+        let payload = ListJson {
+            worktrees: records.as_slice(),
+        };
+        let s = serde_json::to_string_pretty(&payload)?;
+        println!("{s}");
+    } else {
+        print_human(&records, io::stdout())?;
+    }
+    Ok(())
+}
+
+fn print_human(records: &[WorktreeRecord], mut out: impl Write) -> io::Result<()> {
+    if records.is_empty() {
+        writeln!(out, "No worktrees registered for this clone in metadata.")?;
+        return Ok(());
+    }
+
+    for w in records {
+        writeln!(out, "{}", w.name)?;
+        writeln!(out, "  branch:      {}", w.branch)?;
+        writeln!(out, "  base branch: {}", w.base_branch)?;
+        match &w.task {
+            Some(t) => writeln!(out, "  task:        {t}")?,
+            None => writeln!(out, "  task:        —")?,
+        }
+        writeln!(out, "  path:        {}", w.path.display())?;
+        writeln!(out, "  created:     {}", w.created_at)?;
+        writeln!(out)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_empty_line() {
+        let mut buf = Vec::new();
+        print_human(&[], &mut buf).unwrap();
+        assert!(
+            String::from_utf8(buf)
+                .unwrap()
+                .contains("No worktrees registered")
+        );
+    }
+}

--- a/apps/hecate/src/main.rs
+++ b/apps/hecate/src/main.rs
@@ -13,6 +13,15 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// List worktrees registered for this clone (from metadata).
+    List {
+        /// Print machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Run as if started in this directory (must be inside a Git repo).
+        #[arg(long, value_name = "DIR")]
+        cwd: Option<PathBuf>,
+    },
     /// Create a new branch and worktree for a task, and register it in metadata.
     Start {
         /// Task label (e.g. issue number or short slug); becomes directory name and `task/<slug>` branch.
@@ -26,6 +35,15 @@ enum Command {
 fn main() {
     let cli = Cli::parse();
     match cli.command {
+        Command::List { json, cwd } => {
+            let base = cwd
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| PathBuf::from("."));
+            if let Err(e) = hecate::list::run(&base, json) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
         Command::Start { task, cwd } => {
             let base = cwd
                 .or_else(|| std::env::current_dir().ok())

--- a/apps/hecate/tests/start_workflow.rs
+++ b/apps/hecate/tests/start_workflow.rs
@@ -63,3 +63,32 @@ fn start_registers_worktree_and_metadata() {
     assert_eq!(list[0].name, "77");
     assert_eq!(list[0].task.as_deref(), Some("77"));
 }
+
+#[test]
+fn list_worktrees_for_clone_after_start() {
+    let parking = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+
+    let hecate_dir = repo.path().join(".hecate");
+    fs::create_dir_all(&hecate_dir).unwrap();
+    let root_str = parking.path().to_string_lossy().replace('\\', "/");
+    fs::write(
+        hecate_dir.join("config.toml"),
+        format!("hecate_root = \"{root_str}\"\n"),
+    )
+    .unwrap();
+
+    assert!(
+        hecate::list::worktrees_for_cwd(repo.path())
+            .unwrap()
+            .is_empty()
+    );
+
+    hecate::start::run("99", repo.path()).unwrap();
+    let records = hecate::list::worktrees_for_cwd(repo.path()).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].name, "99");
+    assert_eq!(records[0].branch, "task/99");
+    assert_eq!(records[0].task.as_deref(), Some("99"));
+}


### PR DESCRIPTION
## Summary

Implements **PRD Story 6**: `hecate list` with human-readable output and `--json`, scoped to worktrees registered for the **current clone** in `metadata.json`.

### CLI

- `hecate list` — prints each worktree: name, branch, base branch, task (or em dash if unset), path, created timestamp.
- `hecate list --json` — pretty-printed `{"worktrees":[...]}` using the same `WorktreeRecord` fields as on disk.
- Optional `--cwd DIR` (same pattern as `hecate start`).

### Implementation

- New `apps/hecate/src/list.rs`: resolves repo via `GitRepo::discover`, `load` + `resolve_hecate_root`, `read_metadata`, filters by `clone_identity_key(repo_root)`.
- **Library:** `hecate::list::worktrees_for_cwd` for reuse and tests.
- **Deps:** `serde`, `serde_json` on the `hecate` crate.

### Tests & docs

- Integration test `list_worktrees_for_clone_after_start` in `start_workflow.rs`.
- PRD: Story 6 implementation notes.

## Testing

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.