### PR TITLE
feat(cli): hecate rm by name or path + git worktree remove (Story 7)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -363,6 +363,12 @@ Implement:
 - optional force mode
 - metadata cleanup
 
+Implementation notes:
+
+- **`hecate rm <name>`** or **`hecate rm --path <PATH>`** (exactly one); optional **`--cwd`**, **`--force`** → `git worktree remove --force`.
+- **`hecate-git`:** `GitRepo::worktree_remove`.
+- Resolves metadata for **`clone_identity_key`**, removes matching **`WorktreeRecord`**, drops empty repo keys from the map, **`write_metadata`**.
+
 ### Story 8: `hecate state`
 
 Implement state reporting for:

--- a/apps/hecate/src/lib.rs
+++ b/apps/hecate/src/lib.rs
@@ -1,4 +1,5 @@
 //! Library surface for the Hecate CLI (shared with integration tests).
 
 pub mod list;
+pub mod rm;
 pub mod start;

--- a/apps/hecate/src/main.rs
+++ b/apps/hecate/src/main.rs
@@ -22,6 +22,20 @@ enum Command {
         #[arg(long, value_name = "DIR")]
         cwd: Option<PathBuf>,
     },
+    /// Remove a linked worktree (by registered name or path) and drop metadata.
+    Rm {
+        /// Registered worktree name (from `hecate list`), unless `--path` is set.
+        #[arg(required_unless_present = "path")]
+        name: Option<String>,
+        /// Remove by checkout path (must match a row in metadata for this clone).
+        #[arg(long, value_name = "PATH", required_unless_present = "name")]
+        path: Option<PathBuf>,
+        /// Pass `--force` to `git worktree remove` (e.g. dirty tree or locked).
+        #[arg(long, short)]
+        force: bool,
+        #[arg(long, value_name = "DIR")]
+        cwd: Option<PathBuf>,
+    },
     /// Create a new branch and worktree for a task, and register it in metadata.
     Start {
         /// Task label (e.g. issue number or short slug); becomes directory name and `task/<slug>` branch.
@@ -40,6 +54,20 @@ fn main() {
                 .or_else(|| std::env::current_dir().ok())
                 .unwrap_or_else(|| PathBuf::from("."));
             if let Err(e) = hecate::list::run(&base, json) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+        Command::Rm {
+            name,
+            path,
+            force,
+            cwd,
+        } => {
+            let base = cwd
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| PathBuf::from("."));
+            if let Err(e) = hecate::rm::run(&base, name, path, force) {
                 eprintln!("{e}");
                 std::process::exit(1);
             }

--- a/apps/hecate/src/rm.rs
+++ b/apps/hecate/src/rm.rs
@@ -1,0 +1,138 @@
+//! `hecate rm` — remove a linked worktree and drop its metadata entry.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use hecate_config::{
+    LoadOptions, ResolveHecateRootError, WorktreeRecord, clone_identity_key, load, read_metadata,
+    resolve_hecate_root, write_metadata,
+};
+use hecate_git::GitRepo;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RmError {
+    #[error(transparent)]
+    Git(#[from] hecate_git::GitError),
+
+    #[error(transparent)]
+    Config(#[from] hecate_config::ConfigError),
+
+    #[error(transparent)]
+    ResolveRoot(#[from] ResolveHecateRootError),
+
+    #[error(transparent)]
+    Metadata(#[from] hecate_config::MetadataError),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("no worktree matched `{0}` for this clone in metadata")]
+    NotFound(String),
+
+    #[error("this clone has no worktrees registered in metadata")]
+    NoWorktreesRegistered,
+}
+
+fn absolute_norm(path: &Path, cwd: &Path) -> PathBuf {
+    let p = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    std::path::absolute(&p).unwrap_or(p)
+}
+
+fn path_matches_record(record_path: &Path, user: &Path, cwd: &Path) -> bool {
+    let u = absolute_norm(user, cwd);
+    let r = std::path::absolute(record_path).unwrap_or_else(|_| record_path.to_path_buf());
+    if u == r {
+        return true;
+    }
+    match (fs::canonicalize(&u), fs::canonicalize(record_path)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn find_index(
+    list: &[WorktreeRecord],
+    name: Option<&str>,
+    path: Option<&Path>,
+    cwd: &Path,
+) -> Option<usize> {
+    if let Some(n) = name {
+        return list.iter().position(|r| r.name == n);
+    }
+    let p = path?;
+    list.iter()
+        .position(|r| path_matches_record(&r.path, p, cwd))
+}
+
+pub fn run(
+    cwd: &Path,
+    name: Option<String>,
+    path: Option<PathBuf>,
+    force: bool,
+) -> Result<(), RmError> {
+    let git = GitRepo::discover(cwd)?;
+    let opts = LoadOptions {
+        repo_root: Some(git.root().to_path_buf()),
+        config_home_override: None,
+    };
+    let cfg = load(&opts)?;
+    let hecate_root = resolve_hecate_root(cfg.hecate_root.as_deref(), git.root())?;
+    let clone_key = clone_identity_key(git.root());
+    let mut meta = read_metadata(&hecate_root)?;
+
+    let list = meta
+        .repos
+        .get_mut(&clone_key)
+        .ok_or(RmError::NoWorktreesRegistered)?;
+
+    let idx = find_index(list.as_slice(), name.as_deref(), path.as_deref(), cwd)
+        .ok_or_else(|| RmError::NotFound(label(name.as_deref(), path.as_deref())))?;
+
+    let record = list[idx].clone();
+    git.worktree_remove(&record.path, force)?;
+
+    list.remove(idx);
+    if list.is_empty() {
+        meta.repos.remove(&clone_key);
+    }
+
+    write_metadata(&hecate_root, &meta)?;
+
+    println!(
+        "Removed worktree `{}` ({})",
+        record.name,
+        record.path.display()
+    );
+    Ok(())
+}
+
+fn label(name: Option<&str>, path: Option<&Path>) -> String {
+    match (name, path) {
+        (Some(n), None) => n.to_string(),
+        (None, Some(p)) => p.display().to_string(),
+        _ => "(no target)".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_matches_absolute_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("wt");
+        fs::create_dir_all(&sub).unwrap();
+        let canon = fs::canonicalize(&sub).unwrap();
+        assert!(path_matches_record(
+            &canon,
+            tmp.path().join("wt").as_path(),
+            tmp.path()
+        ));
+    }
+}

--- a/apps/hecate/tests/start_workflow.rs
+++ b/apps/hecate/tests/start_workflow.rs
@@ -92,3 +92,32 @@ fn list_worktrees_for_clone_after_start() {
     assert_eq!(records[0].branch, "task/99");
     assert_eq!(records[0].task.as_deref(), Some("99"));
 }
+
+#[test]
+fn rm_by_name_removes_checkout_and_metadata() {
+    let parking = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+
+    let hecate_dir = repo.path().join(".hecate");
+    fs::create_dir_all(&hecate_dir).unwrap();
+    let root_str = parking.path().to_string_lossy().replace('\\', "/");
+    fs::write(
+        hecate_dir.join("config.toml"),
+        format!("hecate_root = \"{root_str}\"\n"),
+    )
+    .unwrap();
+
+    hecate::start::run("42", repo.path()).unwrap();
+    let seg = hecate_core::repo_default_segment(repo.path()).unwrap();
+    let wt = parking.path().join(&seg).join("42");
+    assert!(wt.join("f.txt").exists());
+
+    hecate::rm::run(repo.path(), Some("42".into()), None, false).unwrap();
+    assert!(!wt.exists());
+    assert!(
+        hecate::list::worktrees_for_cwd(repo.path())
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/crates/hecate-git/src/lib.rs
+++ b/crates/hecate-git/src/lib.rs
@@ -123,6 +123,33 @@ impl GitRepo {
         }
         Ok(())
     }
+
+    /// `git worktree remove [--force] <path>` (path is the linked checkout directory).
+    pub fn worktree_remove(&self, path: &Path, force: bool) -> Result<(), GitError> {
+        let mut cmd = Command::new("git");
+        cmd.current_dir(self.root())
+            .args(["worktree", "remove"])
+            .arg(path);
+        if force {
+            cmd.arg("--force");
+        }
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            return Err(GitError::Failed {
+                cmd: {
+                    let mut v = vec!["git".into(), "worktree".into(), "remove".into()];
+                    if force {
+                        v.push("--force".into());
+                    }
+                    v.push(path.display().to_string());
+                    v
+                },
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -174,6 +201,9 @@ mod tests {
         repo.worktree_add_branch(&wt, "task/1", "HEAD").unwrap();
         assert!(wt.join("README.md").exists());
         assert!(repo.local_branch_exists("task/1").unwrap());
+
+        repo.worktree_remove(&wt, false).unwrap();
+        assert!(!wt.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **PRD Story 7**: `hecate rm` — remove a linked worktree via **registered name** or **checkout path**, run `git worktree remove`, and drop the matching row from `metadata.json`.

### CLI

- `hecate rm <name>` — worktree name as shown by `hecate list` / created by `hecate start`.
- `hecate rm --path <PATH>` — filesystem path to the checkout; resolved against `cwd`, matched to metadata with `absolute` / `canonicalize` when possible.
- Exactly one of name or path is required (clap `required_unless_present`).
- `--force` / `-f` → `git worktree remove --force` (dirty tree, lock, etc.).
- Optional `--cwd DIR` (same pattern as `start` / `list`).

### hecate-git

- `GitRepo::worktree_remove(path, force)` — wraps `git worktree remove [--force] <path>` from the main repo.
- Existing worktree test extended to remove the added worktree and assert the directory is gone.

### hecate `rm` module

- Loads config, `resolve_hecate_root`, `read_metadata`, `clone_identity_key`.
- Errors: `NoWorktreesRegistered` when this clone has no metadata entry; `NotFound` when no row matches.
- After successful Git remove: remove `WorktreeRecord`, drop empty `repos` keys, `write_metadata`.

### Known behavior (documented)

- **Branch refs are not deleted** — `git worktree remove` does not remove the branch; `task/<slug>` may remain until `git branch -d` / `-D`. Follow-up could add optional branch deletion.

### Tests & docs

- Integration: `rm_by_name_removes_checkout_and_metadata` in `start_workflow.rs`.
- Unit: path matching helper test in `rm.rs`.
- PRD: Story 7 implementation notes.

## Testing

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.