### PR TITLE
feat(cli): hecate state with --json; load_without_env_hecate_root (St…

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -379,6 +379,13 @@ Implement state reporting for:
 - configured `hecate_root`
 - tracked worktree count
 
+Implementation notes:
+
+- **`hecate state`** / **`hecate state --json`**; optional **`--cwd`**.
+- Shows **absolute** repo root, **current branch** or **(detached HEAD)**, **configured** `hecate_root` (merged config value), **resolved** absolute `hecate_root`, **`metadata_path`**, and **worktree count** for this clone from metadata (0 if unset or no rows).
+- **Library:** `hecate::state::gather` / `gather_opts` / `StateSnapshot` / `StateOptions` (tests: isolated `config_home_override`, optional skip of **`HECATE_ROOT`**).
+- **`hecate-config`:** **`load_without_env_hecate_root`** — same TOML merge as **`load`** but does not read **`HECATE_ROOT`** (used when gathering state with `use_process_hecate_env: false`).
+
 ## Epic 3: GitHub-First Workflow
 
 ### Story 9: GitHub issue resolution

--- a/apps/hecate/src/lib.rs
+++ b/apps/hecate/src/lib.rs
@@ -3,3 +3,4 @@
 pub mod list;
 pub mod rm;
 pub mod start;
+pub mod state;

--- a/apps/hecate/src/main.rs
+++ b/apps/hecate/src/main.rs
@@ -36,6 +36,14 @@ enum Command {
         #[arg(long, value_name = "DIR")]
         cwd: Option<PathBuf>,
     },
+    /// Show repository, branch, hecate_root, metadata path, and tracked worktree count.
+    State {
+        /// Print machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        #[arg(long, value_name = "DIR")]
+        cwd: Option<PathBuf>,
+    },
     /// Create a new branch and worktree for a task, and register it in metadata.
     Start {
         /// Task label (e.g. issue number or short slug); becomes directory name and `task/<slug>` branch.
@@ -68,6 +76,15 @@ fn main() {
                 .or_else(|| std::env::current_dir().ok())
                 .unwrap_or_else(|| PathBuf::from("."));
             if let Err(e) = hecate::rm::run(&base, name, path, force) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+        Command::State { json, cwd } => {
+            let base = cwd
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| PathBuf::from("."));
+            if let Err(e) = hecate::state::run(&base, json) {
                 eprintln!("{e}");
                 std::process::exit(1);
             }

--- a/apps/hecate/src/state.rs
+++ b/apps/hecate/src/state.rs
@@ -1,0 +1,170 @@
+//! `hecate state` — repo + config + metadata summary.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use hecate_config::{
+    LoadOptions, MetadataError, ResolveHecateRootError, clone_identity_key, load,
+    load_without_env_hecate_root, metadata_path, read_metadata, resolve_hecate_root,
+};
+use hecate_git::{GitError, GitRepo};
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StateError {
+    #[error(transparent)]
+    Git(#[from] GitError),
+
+    #[error(transparent)]
+    Config(#[from] hecate_config::ConfigError),
+
+    #[error(transparent)]
+    ResolveRoot(#[from] ResolveHecateRootError),
+
+    #[error(transparent)]
+    Metadata(#[from] MetadataError),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// Overrides for [`gather_opts`] (e.g. tests: isolated `config_home_override`).
+#[derive(Debug, Clone)]
+pub struct StateOptions {
+    pub config_home_override: Option<PathBuf>,
+    /// When `false`, **`HECATE_ROOT`** is not read (deterministic tests).
+    pub use_process_hecate_env: bool,
+}
+
+impl Default for StateOptions {
+    fn default() -> Self {
+        Self {
+            config_home_override: None,
+            use_process_hecate_env: true,
+        }
+    }
+}
+
+/// Snapshot for display and JSON.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct StateSnapshot {
+    /// Git repository top-level (absolute).
+    pub repo_root: PathBuf,
+    /// Current branch short name, or `None` if detached or unknown.
+    pub current_branch: Option<String>,
+    /// `hecate_root` after config merge (before `resolve_hecate_root`), if any.
+    pub hecate_root_configured: Option<PathBuf>,
+    /// Absolute `hecate_root`, if configured.
+    pub hecate_root_resolved: Option<PathBuf>,
+    /// `{hecate_root}/metadata.json` when `hecate_root` is configured.
+    pub metadata_path: Option<PathBuf>,
+    /// Rows in metadata for this clone (`clone_identity_key`).
+    pub worktree_count: usize,
+}
+
+pub fn gather(cwd: &Path) -> Result<StateSnapshot, StateError> {
+    gather_opts(cwd, StateOptions::default())
+}
+
+pub fn gather_opts(cwd: &Path, state_opts: StateOptions) -> Result<StateSnapshot, StateError> {
+    let git = GitRepo::discover(cwd)?;
+    let repo_root = std::path::absolute(git.root())?;
+
+    let current_branch = match git.current_branch() {
+        Ok(b) => Some(b),
+        Err(GitError::DetachedHead) => None,
+        Err(e) => return Err(e.into()),
+    };
+
+    let opts = LoadOptions {
+        repo_root: Some(git.root().to_path_buf()),
+        config_home_override: state_opts.config_home_override,
+    };
+    let cfg = if state_opts.use_process_hecate_env {
+        load(&opts)?
+    } else {
+        load_without_env_hecate_root(&opts)?
+    };
+    let hecate_root_configured = cfg.hecate_root.clone();
+
+    let (hecate_root_resolved, metadata_path, worktree_count) =
+        match resolve_hecate_root(cfg.hecate_root.as_deref(), git.root()) {
+            Ok(root) => {
+                let mp = metadata_path(&root);
+                let meta = read_metadata(&root)?;
+                let key = clone_identity_key(git.root());
+                let n = meta.repos.get(&key).map(|v| v.len()).unwrap_or(0);
+                (Some(root), Some(mp), n)
+            }
+            Err(ResolveHecateRootError::NotConfigured) => (None, None, 0),
+            Err(e) => return Err(e.into()),
+        };
+
+    Ok(StateSnapshot {
+        repo_root,
+        current_branch,
+        hecate_root_configured,
+        hecate_root_resolved,
+        metadata_path,
+        worktree_count,
+    })
+}
+
+pub fn run(cwd: &Path, json: bool) -> Result<(), StateError> {
+    let snap = gather(cwd)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&snap)?);
+    } else {
+        print_human(&snap, io::stdout())?;
+    }
+    Ok(())
+}
+
+fn print_human(s: &StateSnapshot, mut out: impl Write) -> io::Result<()> {
+    writeln!(out, "Repository:    {}", s.repo_root.display())?;
+    match &s.current_branch {
+        Some(b) => writeln!(out, "Branch:        {b}")?,
+        None => writeln!(out, "Branch:        (detached HEAD)")?,
+    }
+
+    match &s.hecate_root_configured {
+        Some(p) => writeln!(out, "hecate_root (configured): {}", p.display())?,
+        None => writeln!(out, "hecate_root (configured): (not set)")?,
+    }
+    match &s.hecate_root_resolved {
+        Some(p) => writeln!(out, "hecate_root (resolved):   {}", p.display())?,
+        None => writeln!(out, "hecate_root (resolved):   (not set)")?,
+    }
+    match &s.metadata_path {
+        Some(p) => writeln!(out, "Metadata file:            {}", p.display())?,
+        None => writeln!(out, "Metadata file:            (not set)")?,
+    }
+    writeln!(out, "Tracked worktrees:        {}", s.worktree_count)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_includes_repo_line() {
+        let snap = StateSnapshot {
+            repo_root: PathBuf::from("/tmp/r"),
+            current_branch: Some("main".into()),
+            hecate_root_configured: None,
+            hecate_root_resolved: None,
+            metadata_path: None,
+            worktree_count: 0,
+        };
+        let mut buf = Vec::new();
+        print_human(&snap, &mut buf).unwrap();
+        let t = String::from_utf8(buf).unwrap();
+        assert!(t.contains("Repository:"));
+        assert!(t.contains("main"));
+    }
+}

--- a/apps/hecate/tests/start_workflow.rs
+++ b/apps/hecate/tests/start_workflow.rs
@@ -121,3 +121,55 @@ fn rm_by_name_removes_checkout_and_metadata() {
             .is_empty()
     );
 }
+
+#[test]
+fn state_without_hecate_root_shows_unconfigured() {
+    let repo = tempfile::tempdir().unwrap();
+    let isolated_home = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    let s = hecate::state::gather_opts(
+        repo.path(),
+        hecate::state::StateOptions {
+            config_home_override: Some(isolated_home.path().to_path_buf()),
+            use_process_hecate_env: false,
+        },
+    )
+    .unwrap();
+    assert_eq!(s.current_branch.as_deref(), Some("main"));
+    assert!(s.hecate_root_configured.is_none());
+    assert!(s.hecate_root_resolved.is_none());
+    assert!(s.metadata_path.is_none());
+    assert_eq!(s.worktree_count, 0);
+}
+
+#[test]
+fn state_counts_tracked_worktrees() {
+    let parking = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+
+    let hecate_dir = repo.path().join(".hecate");
+    fs::create_dir_all(&hecate_dir).unwrap();
+    let root_str = parking.path().to_string_lossy().replace('\\', "/");
+    fs::write(
+        hecate_dir.join("config.toml"),
+        format!("hecate_root = \"{root_str}\"\n"),
+    )
+    .unwrap();
+
+    let isolated_home = tempfile::tempdir().unwrap();
+    let opts = hecate::state::StateOptions {
+        config_home_override: Some(isolated_home.path().to_path_buf()),
+        use_process_hecate_env: false,
+    };
+    let before = hecate::state::gather_opts(repo.path(), opts.clone()).unwrap();
+    assert_eq!(before.worktree_count, 0);
+    assert_eq!(
+        before.metadata_path,
+        Some(hecate_config::metadata_path(parking.path()))
+    );
+
+    hecate::start::run("5", repo.path()).unwrap();
+    let after = hecate::state::gather_opts(repo.path(), opts).unwrap();
+    assert_eq!(after.worktree_count, 1);
+}

--- a/crates/hecate-config/src/lib.rs
+++ b/crates/hecate-config/src/lib.rs
@@ -15,7 +15,7 @@ mod resolve;
 mod types;
 
 pub use error::ConfigError;
-pub use load::{LoadOptions, load};
+pub use load::{LoadOptions, load, load_without_env_hecate_root};
 pub use metadata::{
     METADATA_VERSION, MetadataError, MetadataFile, WorktreeRecord, metadata_path, read_metadata,
     write_metadata,

--- a/crates/hecate-config/src/load.rs
+++ b/crates/hecate-config/src/load.rs
@@ -25,6 +25,11 @@ pub fn load(options: &LoadOptions) -> Result<ResolvedConfig, ConfigError> {
     load_merged(options, from_env)
 }
 
+/// Same merge as [`load`], but does **not** read **`HECATE_ROOT`** from the process environment.
+pub fn load_without_env_hecate_root(options: &LoadOptions) -> Result<ResolvedConfig, ConfigError> {
+    load_merged(options, None)
+}
+
 /// Like [`load`], but uses `env_hecate_root` instead of reading the process
 /// environment (for tests and embedding).
 pub(crate) fn load_merged(


### PR DESCRIPTION
## Summary

Implements **PRD Story 8**: `hecate state` / `hecate state --json` — repo, branch, `hecate_root` (configured + resolved), metadata path, and tracked worktree count for the current clone.

### CLI

- `hecate state` — human-readable: absolute repo root, current branch or **(detached HEAD)**, merged `hecate_root` from TOML, resolved absolute `hecate_root`, `metadata.json` path, worktree row count from metadata (`clone_identity_key`).
- `hecate state --json` — pretty-printed `StateSnapshot` (`repo_root`, `current_branch`, `hecate_root_configured`, `hecate_root_resolved`, `metadata_path`, `worktree_count`).
- Optional `--cwd DIR`.

### hecate app (`state` module)

- `gather` / `gather_opts` / `StateSnapshot` / `StateOptions`.
- Default CLI path uses `load()` so **`HECATE_ROOT`** still applies.
- `StateOptions::use_process_hecate_env: false` + fake `config_home_override` for deterministic integration tests (no user machine `~/.config` or env bleed).

### hecate-config

- **`load_without_env_hecate_root`** — same TOML merge as `load`, but does **not** read **`HECATE_ROOT`** (tests / embedding).

### Tests & docs

- `state_without_hecate_root_shows_unconfigured`, `state_counts_tracked_worktrees` in `start_workflow.rs`.
- PRD Story 8 implementation notes.

## Testing

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.