### PR TITLE
feat(github): fetch issues via gh CLI instead of REST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "hecate-config",
  "hecate-core",
  "hecate-git",
+ "hecate-host-github",
  "serde",
  "serde_json",
  "tempfile",
@@ -357,12 +358,18 @@ dependencies = [
 [[package]]
 name = "hecate-host"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hecate-host-github"
 version = "0.1.0"
 dependencies = [
  "hecate-host",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/PRD.md
+++ b/PRD.md
@@ -393,6 +393,13 @@ Implementation notes:
 Add GitHub issue lookup so numeric task references can become rich task
 objects.
 
+Implementation notes:
+
+- **`hecate-host`:** shared **`Issue`** type (`number`, `title`, `state`, `html_url`, `body`).
+- **`hecate-host-github`:** **`gh api repos/{owner}/{repo}/issues/{number}`** (GitHub CLI auth via **`gh auth login`**); parse **`owner/repo`** from **`git remote get-url origin`** (`github.com` HTTPS/SSH) or **`--repo OWNER/REPO`**. A direct HTTP adapter may be added later.
+- **CLI:** **`hecate issue show <NUMBER>`** with **`--json`**, **`--cwd`**, **`--repo`**.
+- **`hecate-git`:** **`GitRepo::remote_url`**.
+
 ### Story 10: GitHub-backed task start
 
 Allow `hecate start 123` to enrich task context with GitHub issue data.

--- a/apps/hecate/Cargo.toml
+++ b/apps/hecate/Cargo.toml
@@ -13,6 +13,7 @@ clap = { workspace = true }
 hecate-config = { path = "../../crates/hecate-config" }
 hecate-core = { path = "../../crates/hecate-core" }
 hecate-git = { path = "../../crates/hecate-git" }
+hecate-host-github = { path = "../../crates/hecate-host-github" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/apps/hecate/src/issue.rs
+++ b/apps/hecate/src/issue.rs
@@ -1,0 +1,46 @@
+//! `hecate issue show` — GitHub issue lookup for numeric task refs.
+
+use std::path::Path;
+
+use hecate_git::GitRepo;
+use hecate_host_github::{fetch_issue, resolve_owner_repo};
+use serde_json::Error as JsonError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum IssueShowError {
+    #[error(transparent)]
+    Git(#[from] hecate_git::GitError),
+
+    #[error(transparent)]
+    GitHub(#[from] hecate_host_github::GitHubError),
+
+    #[error(transparent)]
+    Json(#[from] JsonError),
+}
+
+pub fn run_show(
+    cwd: &Path,
+    number: u64,
+    json: bool,
+    repo_override: Option<String>,
+) -> Result<(), IssueShowError> {
+    let git = GitRepo::discover(cwd)?;
+    let origin_url = git.remote_url("origin")?;
+    let (owner, repo) = resolve_owner_repo(&origin_url, repo_override.as_deref())?;
+    let issue = fetch_issue(&owner, &repo, number)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&issue)?);
+    } else {
+        println!("#{} [{}] {}", issue.number, issue.state, issue.title);
+        println!("{}", issue.html_url);
+        if let Some(body) = &issue.body {
+            if !body.is_empty() {
+                println!();
+                println!("{body}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/apps/hecate/src/lib.rs
+++ b/apps/hecate/src/lib.rs
@@ -1,5 +1,6 @@
 //! Library surface for the Hecate CLI (shared with integration tests).
 
+pub mod issue;
 pub mod list;
 pub mod rm;
 pub mod start;

--- a/apps/hecate/src/main.rs
+++ b/apps/hecate/src/main.rs
@@ -13,6 +13,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// GitHub issue lookup (numeric task refs).
+    Issue {
+        #[command(subcommand)]
+        command: IssueCommand,
+    },
     /// List worktrees registered for this clone (from metadata).
     List {
         /// Print machine-readable JSON.
@@ -54,9 +59,41 @@ enum Command {
     },
 }
 
+#[derive(Subcommand)]
+enum IssueCommand {
+    /// Print issue title, URL, and body from the GitHub API.
+    Show {
+        /// Issue or PR number on GitHub.
+        number: u64,
+        /// Print JSON (`hecate_host::Issue`).
+        #[arg(long)]
+        json: bool,
+        #[arg(long, value_name = "DIR")]
+        cwd: Option<PathBuf>,
+        /// `owner/repo` on github.com (skip inferring from `origin`).
+        #[arg(long, value_name = "OWNER/REPO")]
+        repo: Option<String>,
+    },
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
+        Command::Issue { command } => {
+            let IssueCommand::Show {
+                number,
+                json,
+                cwd,
+                repo,
+            } = command;
+            let base = cwd
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| PathBuf::from("."));
+            if let Err(e) = hecate::issue::run_show(&base, number, json, repo) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
         Command::List { json, cwd } => {
             let base = cwd
                 .or_else(|| std::env::current_dir().ok())

--- a/crates/hecate-git/src/lib.rs
+++ b/crates/hecate-git/src/lib.rs
@@ -69,6 +69,11 @@ impl GitRepo {
         &self.root
     }
 
+    /// `git remote get-url <name>` (e.g. `origin`).
+    pub fn remote_url(&self, remote: &str) -> Result<String, GitError> {
+        git_output(self.root(), &["remote", "get-url", remote])
+    }
+
     /// Short name of the checked-out branch, or [`GitError::DetachedHead`].
     pub fn current_branch(&self) -> Result<String, GitError> {
         let out = git_output(self.root(), &["symbolic-ref", "-q", "--short", "HEAD"]).map_err(

--- a/crates/hecate-host-github/Cargo.toml
+++ b/crates/hecate-host-github/Cargo.toml
@@ -9,6 +9,9 @@ rust-version.workspace = true
 
 [dependencies]
 hecate-host = { path = "../hecate-host" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/hecate-host-github/src/client.rs
+++ b/crates/hecate-host-github/src/client.rs
@@ -1,0 +1,58 @@
+//! GitHub via **`gh api`** (GitHub CLI auth — no `GITHUB_TOKEN` in hecate).
+
+use hecate_host::Issue;
+use serde::Deserialize;
+use serde_json::Error as SerdeJsonError;
+use std::process::Command;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GitHubError {
+    #[error("gh failed: {stderr}")]
+    Gh { stderr: String },
+
+    #[error(
+        "failed to run gh (install GitHub CLI from https://cli.github.com and run `gh auth login`): {0}"
+    )]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to parse gh JSON output: {0}")]
+    Json(#[from] SerdeJsonError),
+
+    #[error("use --repo OWNER/REPO or set `origin` to a github.com remote (got: {0})")]
+    UnresolvedRepo(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct GhIssue {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    body: Option<String>,
+}
+
+/// Fetch issue (or PR) metadata via **`gh api repos/{owner}/{repo}/issues/{number}`**.
+///
+/// Uses the same auth as **`gh`** (`gh auth login`); no direct HTTP or PAT in hecate.
+pub fn fetch_issue(owner: &str, repo: &str, number: u64) -> Result<Issue, GitHubError> {
+    let endpoint = format!("repos/{owner}/{repo}/issues/{number}");
+    let output = Command::new("gh")
+        .args(["api", &endpoint])
+        .args(["--header", "Accept: application/vnd.github+json"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GitHubError::Gh { stderr });
+    }
+
+    let gh: GhIssue = serde_json::from_slice(&output.stdout)?;
+    Ok(Issue {
+        number: gh.number,
+        title: gh.title,
+        state: gh.state,
+        html_url: gh.html_url,
+        body: gh.body,
+    })
+}

--- a/crates/hecate-host-github/src/lib.rs
+++ b/crates/hecate-host-github/src/lib.rs
@@ -1,4 +1,27 @@
-//! GitHub API and workflow integration (later stories).
+//! GitHub integration for hecate via the **`gh`** CLI.
+
+mod client;
+mod remote;
+
+pub use client::{GitHubError, fetch_issue};
+pub use remote::{owner_repo_from_remote_url, owner_repo_from_slash};
+
+/// Resolve `owner` / `repo` from `--repo OWNER/REPO` or a `git` remote URL.
+pub fn resolve_owner_repo(
+    origin_url: &str,
+    repo_override: Option<&str>,
+) -> Result<(String, String), GitHubError> {
+    if let Some(spec) = repo_override {
+        return owner_repo_from_slash(spec).ok_or_else(|| {
+            GitHubError::UnresolvedRepo(format!("invalid --repo {spec:?} (expected OWNER/REPO)"))
+        });
+    }
+    owner_repo_from_remote_url(origin_url).ok_or_else(|| {
+        GitHubError::UnresolvedRepo(format!(
+            "could not parse github.com owner/repo from remote URL {origin_url:?}"
+        ))
+    })
+}
 
 /// Keeps `hecate-host-github` wired to `hecate-host` in the dependency graph.
 pub fn host_crate_linked() -> &'static str {

--- a/crates/hecate-host-github/src/remote.rs
+++ b/crates/hecate-host-github/src/remote.rs
@@ -1,0 +1,72 @@
+//! Parse `owner` / `repo` from common `github.com` remote URL shapes.
+
+/// `owner/repo` from TOML/CLI override (not a URL).
+pub fn owner_repo_from_slash(spec: &str) -> Option<(String, String)> {
+    let s = spec.trim();
+    let (a, b) = s.split_once('/')?;
+    if a.is_empty() || b.is_empty() || a.contains('/') || b.contains('/') {
+        return None;
+    }
+    Some((a.to_string(), b.to_string()))
+}
+
+/// Best-effort parse for `https://github.com/o/r`, `git@github.com:o/r.git`, etc.
+pub fn owner_repo_from_remote_url(url: &str) -> Option<(String, String)> {
+    let u = url.trim();
+
+    if let Some(rest) = u.strip_prefix("git@github.com:") {
+        return split_owner_repo(rest);
+    }
+    if let Some(rest) = u.strip_prefix("ssh://git@github.com/") {
+        return split_owner_repo(rest);
+    }
+
+    let lower = u.to_ascii_lowercase();
+    let idx = lower.find("github.com/")?;
+    let mut tail = &u[idx + "github.com/".len()..];
+    if let Some(i) = tail.find('?') {
+        tail = &tail[..i];
+    }
+    if let Some(i) = tail.find('#') {
+        tail = &tail[..i];
+    }
+    split_owner_repo(tail.trim_end_matches('/'))
+}
+
+fn split_owner_repo(path: &str) -> Option<(String, String)> {
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let (owner, repo) = path.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_short_form() {
+        assert_eq!(
+            owner_repo_from_remote_url("git@github.com:foo/bar.git"),
+            Some(("foo".into(), "bar".into()))
+        );
+    }
+
+    #[test]
+    fn https() {
+        assert_eq!(
+            owner_repo_from_remote_url("https://github.com/foo/bar"),
+            Some(("foo".into(), "bar".into()))
+        );
+    }
+
+    #[test]
+    fn slash_spec() {
+        assert_eq!(
+            owner_repo_from_slash("myorg/hecate"),
+            Some(("myorg".into(), "hecate".into()))
+        );
+    }
+}

--- a/crates/hecate-host/Cargo.toml
+++ b/crates/hecate-host/Cargo.toml
@@ -7,5 +7,8 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+serde = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/hecate-host/src/issue.rs
+++ b/crates/hecate-host/src/issue.rs
@@ -1,0 +1,13 @@
+//! Code-host–agnostic issue representation (filled by adapters such as GitHub).
+
+use serde::{Deserialize, Serialize};
+
+/// A single issue (or pull request on hosts that expose PRs through the issues API).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Issue {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub html_url: String,
+    pub body: Option<String>,
+}

--- a/crates/hecate-host/src/lib.rs
+++ b/crates/hecate-host/src/lib.rs
@@ -1,4 +1,8 @@
 //! Task and pull-request abstractions shared across code hosts.
 
+pub mod issue;
+
+pub use issue::Issue;
+
 /// Marker that this crate is part of the workspace graph.
 pub const LINK_CHECK: &str = "hecate-host";


### PR DESCRIPTION
## Summary

Adds **`hecate issue show <NUMBER>`** so numeric task refs can be resolved against GitHub. Issue metadata is fetched **only through the GitHub CLI** (`gh api …`); there is **no direct REST client** or `GITHUB_TOKEN` / `GH_TOKEN` handling in-tree (a separate HTTP adapter can come later).

## What changed

- **`hecate-host`:** shared **`Issue`** type (`number`, `title`, `state`, `html_url`, `body`).
- **`hecate-host-github`:** resolve **`owner/repo`** from `origin` (github.com HTTPS/SSH) or **`--repo OWNER/REPO`**; **`fetch_issue`** shells out to **`gh api repos/{owner}/{repo}/issues/{number}`** and parses JSON.
- **`hecate-git`:** **`GitRepo::remote_url`** for reading `git remote get-url`.
- **CLI:** **`hecate issue show`** with **`--json`**, **`--cwd`**, **`--repo`**.
- **PRD:** Story 9 implementation notes updated for **gh**-based auth.

## Prerequisites

- [GitHub CLI](https://cli.github.com/) on `PATH`
- **`gh auth login`** (same auth model as other `gh` commands)

## How to try it

```bash
cargo run -p hecate -- issue show 1
cargo run -p hecate -- issue show 1 --json
cargo run -p hecate -- issue show 1 --repo OWNER/REPO
```
